### PR TITLE
Added docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Immediately  start the service via systemd
 sudo systemctl start pvstats.service
 ```
 
+## Docker
+
+To deploy a container:
+* Create a `pvstats.conf` based on `pvstats.conf.example`
+* Run the container with docker run
+
+```
+docker run -v /path/to/config:/config mpfl/pvstats
+```
+
 ## Built with help from the following projects
 
 * [Pymodbus](https://github.com/riptideio/pymodbus/) - Python Modbus client
@@ -91,6 +101,7 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 ## Authors of README.md
 
 * **Paul Archer** - *Modified for pvstats* - [PVStats](https://github.com/ptarcher/pvstats)
+* **Matthias Liffers** - *Containerisation* - [PVStats](http://github.com/mpfl/)
 * **Billie Thompson** - *Initial work* - [PurpleBooth](https://github.com/PurpleBooth)
 
 See also the list of [contributors](https://github.com/ptarcher/pvstats/contributors) who participated in this project.

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,10 @@
+FROM python:2.7
+LABEL maintainer="Matthias Liffers <m@tthi.as>"
+
+VOLUME /config
+
+COPY . /pvstats
+
+RUN pip install ./pvstats
+
+CMD ["/pvstats/bin/pvstats", "--cfg", "/config/pvstats.conf"]

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2-alpine
 LABEL maintainer="Matthias Liffers <m@tthi.as>"
 
 VOLUME /config


### PR DESCRIPTION
I've created a dockerfile and put [a container image on Dockerhub](https://hub.docker.com/r/mpfl/pvstats).

The docker implementation does not require changing any other files as it takes advantage of the already existing `--cfg` command line flag to permit the configuration file to exist external to the container.

The image itself quite small - only 77MB (it was close to 1GB before I swapped to an Alpine based image!)

I've already deployed the container on my home network and the data has been happily uploading to [pvoutput](https://pvoutput.org/list.jsp?id=52176&sid=47433) as of 20/06/2019.