### PR TITLE
SG5KTL: Added 2 extra registers ac_active_power, ac_power_factor.

### DIFF
--- a/pvstats/pvinverter/sungrow_sg5ktl.py
+++ b/pvstats/pvinverter/sungrow_sg5ktl.py
@@ -42,8 +42,10 @@ _register_map = {
     '5013':  {'name': 'pv2_voltage',       'scale': Decimal('0.1'), 'units': 'V'},
     '5014':  {'name': 'pv2_current',       'scale': Decimal('0.1'), 'units': 'A'},
     '5017':  {'name': 'total_pv_power',    'scale': Decimal(1),     'units': 'W'},
-    '5019':  {'name': 'grid_voltage',      'scale': Decimal('0.1'), 'units': 'V'},
-    '5022':  {'name': 'inverter_current',  'scale': Decimal('0.1'), 'units': 'A'},
+    '5019':  {'name': 'ac_voltage',        'scale': Decimal('0.1'), 'units': 'V'},
+    '5022':  {'name': 'ac_current',        'scale': Decimal('0.1'), 'units': 'A'},
+    '5031':  {'name': 'ac_active_power',   'scale': Decimal(1),     'units': 'W'},
+    '5035':  {'name': 'ac_power_factor',   'scale': Decimal(0.001), 'units': ''},
     '5036':  {'name': 'grid_frequency',    'scale': Decimal('0.1'), 'units': 'Hz'},
   },
 


### PR DESCRIPTION
Identified some extra registers for this inverter.

"ac_active power" is useful especially for overclocked inverters as it shows the clipped output rather than the total panel dc power("total_pv_power").

Updated the name for "grid_voltage" to "ac_voltage" for consistency, and also because due to voltage drop between inverter and switchboard connection for example the inverter will report a higher voltage than that at the main switchboard.

