### PR TITLE
Add default HTTP timeout, and some minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ To install the PVStats via pip (Python Package Index)
 pip install pvstats
 ```
 
+### Building
+
+To build PVStats:
+
+First modify `pvstats.conf` with your inverter settings, and also pvoutput.org, MQTT or InfluxDB settings.
+
+```
+chmod +x setup.py
+./setup.py build
+sudo ./setup.py install
+```
+
 ### Running
 
 First modify `pvstats.conf` with your inverter settings, and also pvoutput.org, MQTT or InfluxDB settings

--- a/README.md
+++ b/README.md
@@ -47,8 +47,22 @@ sudo ./setup.py install
 First modify `pvstats.conf` with your inverter settings, and also pvoutput.org, MQTT or InfluxDB settings
 
 ```
-/usr/bin/pvstats -f pvstats.conf
+/usr/bin/pvstats --cfg pvstats.conf
 ```
+
+### Configuration
+
+Inverter model codes currently usable in the configuration are:
+
+* solax
+* fronius
+* sungrow-sg5ktl
+
+Remove from the configuration any reporting endpoints that are not applicable.
+
+Solax and Fronius use HTTP calls to retrieve data. If you have an unstable connection and need to modify request timeout values, you can modify the 'http_timeout_sec' parameter for the inverter.
+
+Similarly you can do the same for the 'pvoutput' report type when POSTing your PV request data.
 
 ## Running the tests
 

--- a/bin/pvstats
+++ b/bin/pvstats
@@ -14,11 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import time
 import json
 from datetime import datetime
 from sys import stdout
 import argparse
+
+sys.path.append('/opt/python3/lib/')
+print(sys.path)
 
 from pvstats.pvinverter.factory import PVInverterFactory
 from pvstats.report import PVReportFactory
@@ -98,3 +102,4 @@ if __name__ == "__main__":
   main()
 
 # vim: set expandtab ts=2 sw=2:
+

--- a/modified-README.md
+++ b/modified-README.md
@@ -1,0 +1,13 @@
+Setup the venv, install modules required.
+
+mkdir -p /opt/python3/venv/pvstats
+python -m venv /opt/python3/venv/pvstats
+/opt/python3/venv/pvstats/bin/python /opt/python3/venv/pvstats/bin/pip install pymodbus
+# probably not needed /opt/python3/venv/pvstats/bin/python /opt/python3/venv/pvstats/bin/pip install serial
+/opt/python3/venv/pvstats/bin/python /opt/python3/venv/pvstats/bin/pip install pyserial
+/opt/python3/venv/pvstats/bin/python /opt/python3/venv/pvstats/bin/pip install influxdb
+/opt/python3/venv/pvstats/bin/python /opt/python3/venv/pvstats/bin/pip install httplib2
+/opt/python3/venv/pvstats/bin/python /opt/python3/venv/pvstats/bin/pip install paho-mqtt
+/opt/python3/venv/pvstats/bin/python /usr/bin/pvstats --cfg /etc/pvstats.conf
+
+Put 'pvstats' directory from this codebase in /opt/python3/lib/  (or modify bin/pvstats to change where it appends pvstats to the sys.path)

--- a/pvstats.conf.example
+++ b/pvstats.conf.example
@@ -3,7 +3,8 @@
     "model":"sungrow-sg5ktl",
     "mode":"tcp",
     "host":"sungrow.example.com",
-    "port":502
+    "port":502,
+    "http_timeout_sec":5
   },
   "reports":[
     {
@@ -35,6 +36,7 @@
     }
   ],
 
+  "report_post_timeout_sec":20,
   "sample_period":10,
   "verbose":1
 }

--- a/pvstats.conf.example
+++ b/pvstats.conf.example
@@ -12,7 +12,8 @@
       "host":"pvoutput.org",
       "rate_limit":"300",
       "key":"TODO",
-      "system_id":"TODO"
+      "system_id":"TODO",
+      "http_timeout_sec":20
     },
     {
       "type": "influxdb",
@@ -36,7 +37,6 @@
     }
   ],
 
-  "report_post_timeout_sec":20,
   "sample_period":10,
   "verbose":1
 }

--- a/pvstats.service
+++ b/pvstats.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/pvstats
+ExecStart=/usr/bin/pvstats --cfg /etc/pvstats.conf
 
 User=nobody
 

--- a/pvstats/pvinverter/base.py
+++ b/pvstats/pvinverter/base.py
@@ -16,8 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pymodbus.constants import Defaults
-from pymodbus.client.sync import ModbusTcpClient
+#from pymodbus.constants import Defaults
+import pymodbus.constants
+from pymodbus.client import ModbusTcpClient
 from pymodbus.transaction import ModbusSocketFramer
 
 class BasePVInverter(object):

--- a/pvstats/pvinverter/factory.py
+++ b/pvstats/pvinverter/factory.py
@@ -19,8 +19,9 @@
 from datetime import datetime
 from decimal import *
 
-from pymodbus.constants import Defaults
-from pymodbus.client.sync import ModbusTcpClient
+#from pymodbus.constants import Defaults
+import pymodbus.constants
+from pymodbus.client import ModbusTcpClient
 from pymodbus.transaction import ModbusSocketFramer
 
 from pvstats.pvinverter.fronius import PVInverter_Fronius

--- a/pvstats/pvinverter/fronius.py
+++ b/pvstats/pvinverter/fronius.py
@@ -27,6 +27,7 @@ _logger = logging.getLogger(__name__)
 class PVInverter_Fronius(BasePVInverter):
   def __init__(self, cfg, **kwargs):
     self.url = "http://{}:{}/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceID=1&DataCollection=CommonInverterData".format(cfg["host"],cfg["port"])
+    self.http_timeout_sec = cfg["http_timeout_sec"]
 
   def connect(self):
     pass
@@ -105,7 +106,7 @@ class PVInverter_Fronius(BasePVInverter):
 }
 """
 
-    response = urllib2.urlopen(self.url).read()
+    response = urllib2.urlopen(self.url, None, self.http_timeout_sec).read()
     data = json.loads(response)
     d = json.dumps(data, sort_keys=True, indent=2, separators=(',', ': '),default=str)
     print d

--- a/pvstats/pvinverter/fronius.py
+++ b/pvstats/pvinverter/fronius.py
@@ -27,7 +27,7 @@ _logger = logging.getLogger(__name__)
 class PVInverter_Fronius(BasePVInverter):
   def __init__(self, cfg, **kwargs):
     self.url = "http://{}:{}/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceID=1&DataCollection=CommonInverterData".format(cfg["host"],cfg["port"])
-    self.http_timeout_sec = cfg["http_timeout_sec"]
+    self.http_timeout_sec = cfg.get("http_timeout_sec", 10)
 
   def connect(self):
     pass

--- a/pvstats/pvinverter/solax.py
+++ b/pvstats/pvinverter/solax.py
@@ -29,7 +29,7 @@ _logger = logging.getLogger(__name__)
 class PVInverter_Solax(BasePVInverter):
   def __init__(self, cfg, **kwargs):
     self.url = "http://{}:{}/api/realTimeData.htm".format(cfg["host"],cfg["port"])
-    self.http_timeout_sec = cfg["http_timeout_sec"]
+    self.http_timeout_sec = cfg.get("http_timeout_sec", 10)
 
     
   def connect(self):

--- a/pvstats/pvinverter/solax.py
+++ b/pvstats/pvinverter/solax.py
@@ -29,6 +29,7 @@ _logger = logging.getLogger(__name__)
 class PVInverter_Solax(BasePVInverter):
   def __init__(self, cfg, **kwargs):
     self.url = "http://{}:{}/api/realTimeData.htm".format(cfg["host"],cfg["port"])
+    self.http_timeout_sec = cfg["http_timeout_sec"]
 
     
   def connect(self):
@@ -40,7 +41,7 @@ class PVInverter_Solax(BasePVInverter):
   def read(self):
     """Reads the PV inverters status"""
 
-    response = urllib2.urlopen(self.url).read().decode("utf-8").replace(",,",",0,").replace(",,",",0,")
+    response = urllib2.urlopen(self.url, None, self.http_timeout_sec).read().decode("utf-8").replace(",,",",0,").replace(",,",",0,")
     data = json.loads(response)
     #print json.dumps(data, sort_keys=True, indent=2, separators=(',', ': '),default=str)
 

--- a/pvstats/pvinverter/sungrow_sg5ktl.py
+++ b/pvstats/pvinverter/sungrow_sg5ktl.py
@@ -16,9 +16,10 @@
 
 from pvstats.pvinverter.base import BasePVInverter
 
-from pymodbus.constants import Defaults
-from pymodbus.client.sync import ModbusTcpClient
-from pymodbus.client.sync import ModbusSerialClient
+#from pymodbus.constants import Defaults
+import pymodbus.constants
+from pymodbus.client import ModbusTcpClient
+from pymodbus.client import ModbusSerialClient
 from pymodbus.transaction import ModbusSocketFramer
 from pymodbus.exceptions import ModbusIOException
 from pymodbus.payload import BinaryPayloadDecoder

--- a/pvstats/pvoutput.py
+++ b/pvstats/pvoutput.py
@@ -20,11 +20,11 @@ import urllib
 import httplib
 
 class PVOutputClient():
-	def __init__(self, host, api_key, system_id, report_post_timeout_sec):
+	def __init__(self, host, api_key, system_id, http_timeout_sec):
 		self.host = host
 		self.api_key = api_key
 		self.system_id = system_id
-                self.post_timeout_sec = report_post_timeout_sec
+                self.http_timeout_sec = http_timeout_sec
 
 	def add_output(self, date, generated, exported=None, peak_power=None, peak_time=None, condition=None,
 			min_temperature=None, max_temperature=None, comments=None, import_peak=None, import_offpeak=None, import_shoulder=None):
@@ -141,7 +141,7 @@ class PVOutputClient():
 		return response.read()
 
 	def make_request(self, method, path, params=None):
-		conn = httplib.HTTPConnection(self.host, timeout = self.post_timeout_sec)
+		conn = httplib.HTTPConnection(self.host, timeout = self.http_timeout_sec)
 		headers = {
 				'Content-type': 'application/x-www-form-urlencoded',
 				'Accept': 'text/plain',

--- a/pvstats/pvoutput.py
+++ b/pvstats/pvoutput.py
@@ -20,10 +20,11 @@ import urllib
 import httplib
 
 class PVOutputClient():
-	def __init__(self, host, api_key, system_id):
+	def __init__(self, host, api_key, system_id, report_post_timeout_sec):
 		self.host = host
 		self.api_key = api_key
 		self.system_id = system_id
+                self.post_timeout_sec = report_post_timeout_sec
 
 	def add_output(self, date, generated, exported=None, peak_power=None, peak_time=None, condition=None,
 			min_temperature=None, max_temperature=None, comments=None, import_peak=None, import_offpeak=None, import_shoulder=None):
@@ -140,7 +141,7 @@ class PVOutputClient():
 		return response.read()
 
 	def make_request(self, method, path, params=None):
-		conn = httplib.HTTPConnection(self.host)
+		conn = httplib.HTTPConnection(self.host, timeout = self.post_timeout_sec)
 		headers = {
 				'Content-type': 'application/x-www-form-urlencoded',
 				'Accept': 'text/plain',

--- a/pvstats/report.py
+++ b/pvstats/report.py
@@ -43,7 +43,8 @@ class PVReport_pvoutput(BasePVOutput):
 
     self.client = PVOutputClient(cfg['host'],
                                  cfg['key'],
-                                 cfg['system_id'])
+                                 cfg['system_id'],
+                                 cfg['report_post_timeout_sec'])
 
   def publish(self, data):
     sample = {'date':             data['timestamp'].strftime("%Y%m%d"),

--- a/pvstats/report.py
+++ b/pvstats/report.py
@@ -44,7 +44,7 @@ class PVReport_pvoutput(BasePVOutput):
     self.client = PVOutputClient(cfg['host'],
                                  cfg['key'],
                                  cfg['system_id'],
-                                 cfg['report_post_timeout_sec'])
+                                 cfg.get('http_timeout_sec', 20))
 
   def publish(self, data):
     sample = {'date':             data['timestamp'].strftime("%Y%m%d"),


### PR DESCRIPTION
I switched to using pvstats today with a solax inverter that is on the edge of my WiFi network and has poor connectivity.

I noticed that pvstats had hung for about an hour without reporting.

I had a check on a hunch and noticed that there were no default HTTP timeouts built in for the solax or fronius inverters, or for POSTing data to PVOutput.

I've added these timeouts as a configurable parameters (http_timeout_sec). 

If not specified it will default to 10 seconds for pulling data from the solax or fronius inverters, and 20 seconds for POSTing data to PVOutput.

I've run with the changes and it seems OK, but I have only tested with the solax inverter and pvoutput report.

I also updated the README.md slightly to add build steps that worked for me, and changed the systemd unit to use '--cfg /etc/pvstats.conf'.

Apologies if I'm not following your contribution standards properly.